### PR TITLE
Results and Organization Data

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -9,7 +9,7 @@ import { assign } from "lodash";
 const routes: Routes = [
   { path: "",  component: SearchPageComponent },
   { path: "results",  component: ResultsPageComponent },
-  { path: "organization",  component: OrganizationPageComponent }
+  { path: "organization/:id",  component: OrganizationPageComponent }
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
 import { BrowserModule } from "@angular/platform-browser";
 import { FormsModule } from '@angular/forms';
+import { HttpModule } from '@angular/http';
 
 // our modules
 import { AppRoutingModule } from "./app-routing.module";
@@ -18,26 +19,27 @@ import { ResultsPageComponent } from "./results-page/results-page.component";
 import { SearchPageComponent } from "./search-page/search-page.component";
 
 @NgModule({
-  bootstrap: [ AppComponent ],
-  declarations: [
-    AppComponent,
-    // pages
-    SearchPageComponent,
-    ResultsPageComponent,
-    OrganizationPageComponent,
-    // components
-    LocationPickerComponent,
-    NavigationComponent
-  ],
-  imports: [
-    BrowserModule,
-    AppRoutingModule,
-    MultiselectDropdownModule,
-    FormsModule,
-    GoogleMapsModule.forRoot({
-      apiKey: "AIzaSyDnyjd_w7FdScc5fU1pc1DwncZOAXgeZMI",
-      libraries: ['places']
-    })
-  ]
+	bootstrap: [ AppComponent ],
+	declarations: [
+		AppComponent,
+		// pages
+		SearchPageComponent,
+		ResultsPageComponent,
+		OrganizationPageComponent,
+		// components
+		LocationPickerComponent,
+		NavigationComponent
+	],
+	imports: [
+		BrowserModule,
+		AppRoutingModule,
+		MultiselectDropdownModule,
+		FormsModule,
+		GoogleMapsModule.forRoot({
+			apiKey: "AIzaSyDnyjd_w7FdScc5fU1pc1DwncZOAXgeZMI",
+			libraries: ['places']
+		}),
+		HttpModule
+	]
 })
 export class AppModule { }

--- a/src/app/organization-page/organization-page.component.spec.ts
+++ b/src/app/organization-page/organization-page.component.spec.ts
@@ -3,28 +3,32 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import {BrowserDynamicTestingModule, platformBrowserDynamicTesting} from "@angular/platform-browser-dynamic/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { HttpModule } from '@angular/http';
 
 import { OrganizationPageComponent } from "./organization-page.component";
 
 describe("OrganizationPageComponent", () => {
-  let de: DebugElement;
-  let comp: OrganizationPageComponent;
-  let fixture: ComponentFixture<OrganizationPageComponent>;
+	let de: DebugElement;
+	let comp: OrganizationPageComponent;
+	let fixture: ComponentFixture<OrganizationPageComponent>;
 
-  beforeEach(async(() => {
-    TestBed
-    .configureTestingModule({
-      declarations: [ OrganizationPageComponent ],
-      imports: [ RouterTestingModule ]
-    })
-    .compileComponents();
-  }));
+	beforeEach(async(() => {
+		TestBed
+		.configureTestingModule({
+			declarations: [ OrganizationPageComponent ],
+			imports: [
+				RouterTestingModule,
+				HttpModule
+			]
+		})
+		.compileComponents();
+	}));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(OrganizationPageComponent);
-    comp = fixture.componentInstance;
-    de = fixture.debugElement.query(By.css("h1"));
-  });
+	beforeEach(() => {
+		fixture = TestBed.createComponent(OrganizationPageComponent);
+		comp = fixture.componentInstance;
+		de = fixture.debugElement.query(By.css("h1"));
+	});
 
-  it("should create component", () => expect(comp).toBeDefined() );
+	it("should create component", () => expect(comp).toBeDefined() );
 });

--- a/src/app/organization-page/organization-page.component.ts
+++ b/src/app/organization-page/organization-page.component.ts
@@ -1,8 +1,44 @@
-import { Component } from "@angular/core";
+import { Component, OnInit, OnDestroy } from "@angular/core";
+import { ActivatedRoute } from '@angular/router';
+
+import { OrganizationService } from '../organization.service';
 
 @Component({
 	selector: "organization-page",
 	styleUrls: [ "./organization-page.css" ],
-	templateUrl: "./organization-page.html"
+	templateUrl: "./organization-page.html",
+	providers: [ OrganizationService ]
 })
-export class OrganizationPageComponent { }
+export class OrganizationPageComponent implements OnInit, OnDestroy {
+	private sub: any;
+
+	organization: any;
+
+	constructor(
+		private route: ActivatedRoute,
+		private organizationService: OrganizationService
+	) {}
+
+	ngOnInit() {
+		this.sub = this.route.params.subscribe(params => {
+			const id = params['id'];
+			this.getDetails(id);
+		});
+	}
+
+	ngOnDestroy() {
+		if (this.sub) {
+			this.sub.unsubscribe();
+		}
+	}
+
+	getDetails(id: string) {
+		console.log('id:', id);
+		this.organizationService.getOrganization(id)
+		.then(organization => {
+			console.log('Organization');
+			console.log(organization);
+			this.organization = organization;
+		});
+	}
+}

--- a/src/app/organization-page/organization-page.html
+++ b/src/app/organization-page/organization-page.html
@@ -1,1 +1,4 @@
-<h3>Organization Page</h3>
+<template [ngIf]="organization">
+	<h3>{{organization.name}}</h3>
+	<p>{{organization.description}}</p>
+</template>

--- a/src/app/organization.service.spec.ts
+++ b/src/app/organization.service.spec.ts
@@ -1,0 +1,16 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { OrganizationService } from './organization.service';
+
+describe('OrganizationService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [OrganizationService]
+    });
+  });
+
+  it('should ...', inject([OrganizationService], (service: OrganizationService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/organization.service.spec.ts
+++ b/src/app/organization.service.spec.ts
@@ -1,16 +1,18 @@
 /* tslint:disable:no-unused-variable */
-
 import { TestBed, async, inject } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
+
 import { OrganizationService } from './organization.service';
 
 describe('OrganizationService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [OrganizationService]
-    });
-  });
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			providers: [ OrganizationService ],
+			imports: [ HttpModule ]
+		});
+	});
 
-  it('should ...', inject([OrganizationService], (service: OrganizationService) => {
-    expect(service).toBeTruthy();
-  }));
+	it('should ...', inject([OrganizationService], (service: OrganizationService) => {
+		expect(service).toBeTruthy();
+	}));
 });

--- a/src/app/organization.service.ts
+++ b/src/app/organization.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { URLSearchParams, Http } from '@angular/http';
+
+import 'rxjs/add/operator/toPromise';
+
+@Injectable()
+export class OrganizationService {
+	private searchUrl: string = "http://hclapi-dev.us-east-2.elasticbeanstalk.com/organization";
+
+	constructor(private http: Http) { }
+
+	getOrganization(id: string) {
+		return this.http.get(`${this.searchUrl}/${id}`)
+		.toPromise()
+		.then(response => response.json())
+		.catch(err => console.log(err));
+	}
+
+}

--- a/src/app/results-page/results-page.component.spec.ts
+++ b/src/app/results-page/results-page.component.spec.ts
@@ -3,28 +3,32 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import {BrowserDynamicTestingModule, platformBrowserDynamicTesting} from "@angular/platform-browser-dynamic/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { HttpModule } from '@angular/http';
 
 import { ResultsPageComponent } from "./results-page.component";
 
 describe("ResultsPageComponent", () => {
-  let de: DebugElement;
-  let comp: ResultsPageComponent;
-  let fixture: ComponentFixture<ResultsPageComponent>;
+	let de: DebugElement;
+	let comp: ResultsPageComponent;
+	let fixture: ComponentFixture<ResultsPageComponent>;
 
-  beforeEach(async(() => {
-    TestBed
-    .configureTestingModule({
-      declarations: [ ResultsPageComponent ],
-      imports: [ RouterTestingModule ]
-    })
-    .compileComponents();
-  }));
+	beforeEach(async(() => {
+		TestBed
+		.configureTestingModule({
+			declarations: [ ResultsPageComponent ],
+			imports: [
+				RouterTestingModule,
+				HttpModule
+			]
+		})
+		.compileComponents();
+	}));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ResultsPageComponent);
-    comp = fixture.componentInstance;
-    de = fixture.debugElement.query(By.css("h1"));
-  });
+	beforeEach(() => {
+		fixture = TestBed.createComponent(ResultsPageComponent);
+		comp = fixture.componentInstance;
+		de = fixture.debugElement.query(By.css("h1"));
+	});
 
-  it("should create component", () => expect(comp).toBeDefined() );
+	it("should create component", () => expect(comp).toBeDefined() );
 });

--- a/src/app/results-page/results-page.component.ts
+++ b/src/app/results-page/results-page.component.ts
@@ -1,19 +1,33 @@
 import { Component, OnInit, OnDestroy } from "@angular/core";
 import { ActivatedRoute } from '@angular/router';
 
+import { SearchService } from '../search.service';
+
+type Service = Object;
+
 @Component({
 	selector: "results-page",
 	styleUrls: [ "./results-page.css" ],
-	templateUrl: "./results-page.html"
+	templateUrl: "./results-page.html",
+	providers: [ SearchService ]
 })
 export class ResultsPageComponent implements OnInit, OnDestroy {
 	private sub: any;
 
-	constructor(private route: ActivatedRoute) {}
+	results: Array<Service>;
+
+	constructor(
+		private route: ActivatedRoute,
+		private searchService: SearchService
+	) {}
 
 	ngOnInit() {
 		this.sub = this.route.queryParams.subscribe(params => {
-			console.log(params);
+			this.getResults(
+				params['latitude'],
+				params['longitude'],
+				params['serviceCodes'].split(',')
+			);
 		});
 	}
 
@@ -21,5 +35,18 @@ export class ResultsPageComponent implements OnInit, OnDestroy {
 		if (this.sub) {
 			this.sub.unsubscribe();
 		}
+	}
+
+	getResults(latitude: string, longitude: string, serviceCodes: Array<string>) {
+		this.searchService.getResults(
+			latitude,
+			longitude,
+			serviceCodes
+		)
+		.then(results => {
+			console.log('Search Results');
+			console.log(results);
+			this.results = results;
+		});
 	}
 }

--- a/src/app/results-page/results-page.component.ts
+++ b/src/app/results-page/results-page.component.ts
@@ -1,8 +1,25 @@
-import { Component } from "@angular/core";
+import { Component, OnInit, OnDestroy } from "@angular/core";
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
 	selector: "results-page",
 	styleUrls: [ "./results-page.css" ],
 	templateUrl: "./results-page.html"
 })
-export class ResultsPageComponent { }
+export class ResultsPageComponent implements OnInit, OnDestroy {
+	private sub: any;
+
+	constructor(private route: ActivatedRoute) {}
+
+	ngOnInit() {
+		this.sub = this.route.queryParams.subscribe(params => {
+			console.log(params);
+		});
+	}
+
+	ngOnDestroy() {
+		if (this.sub) {
+			this.sub.unsubscribe();
+		}
+	}
+}

--- a/src/app/results-page/results-page.html
+++ b/src/app/results-page/results-page.html
@@ -1,2 +1,10 @@
 <h3>Results Page</h3>
-<a routerLink="/organization">Organization</a>
+
+<h4>SEARCH RESULTS</h4>
+<ul>
+	<a  *ngFor="let result of results" routerLink="/organization/{{result.id}}">
+		<li>
+			<p>{{result.name}}</p>
+		</li>
+	</a>
+</ul>

--- a/src/app/search-page/search-page.html
+++ b/src/app/search-page/search-page.html
@@ -8,6 +8,6 @@
 
 <a
 	[routerLink]="['/results']"
-	[queryParams]="{ latitude: location?.latitude, longitude: location?.longitude, serviceCode: selectedServiceCodes }">
+	[queryParams]="{ latitude: location?.latitude, longitude: location?.longitude, serviceCodes: selectedServiceCodes }">
 	Search
 </a>

--- a/src/app/search.service.spec.ts
+++ b/src/app/search.service.spec.ts
@@ -1,12 +1,14 @@
 /* tslint:disable:no-unused-variable */
-
 import { TestBed, async, inject } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
+
 import { SearchService } from './search.service';
 
 describe('SearchService', () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			providers: [SearchService]
+			providers: [ SearchService ],
+			imports: [ HttpModule ]
 		});
 	});
 

--- a/src/app/search.service.spec.ts
+++ b/src/app/search.service.spec.ts
@@ -1,0 +1,16 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject } from '@angular/core/testing';
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			providers: [SearchService]
+		});
+	});
+
+	it('should ...', inject([SearchService], (service: SearchService) => {
+		expect(service).toBeTruthy();
+	}));
+});

--- a/src/app/search.service.ts
+++ b/src/app/search.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { URLSearchParams, Http } from '@angular/http';
+
+import 'rxjs/add/operator/toPromise';
+
+@Injectable()
+export class SearchService {
+	private searchUrl: string = "http://hclapi-dev.us-east-2.elasticbeanstalk.com/search";
+
+	constructor(private http: Http) { }
+
+	getResults(latitude: string, longitude: string, serviceCodes: Array<string>) {
+		const params = new URLSearchParams();
+
+		serviceCodes.forEach(serviceCode => {
+			params.append('serviceCode', serviceCode);
+		});
+
+		params.append('latitude', latitude);
+		params.append('longitude', longitude);
+
+		return this.http.get(this.searchUrl, {
+			search: params
+		})
+		.toPromise()
+		.then(response => response.json().organization_list)
+		.catch(err => console.log(err));
+	}
+
+}


### PR DESCRIPTION
This PR adds all the data needed for the Results and Organization pages. You can see a few of the fields displayed in the html and all of the data written out to the console:

![hcl-data](https://cloud.githubusercontent.com/assets/5851984/22487511/49f0e8d4-e7d3-11e6-9cb4-c457f217edfe.gif)
