### PR TITLE
centering dropdown and location picker on homepage

### DIFF
--- a/src/app/search-page/search-page.css
+++ b/src/app/search-page/search-page.css
@@ -1,12 +1,3 @@
-.searchcontent {
-    margin: 0px;
-    padding: 0px;
-    text-align: center;
-    height: 400px;
-}
-
-.col-md-12 {
-    text-align: center;
-    margin: auto;
-    
+ss-multiselect-dropdown {
+	float: right;
 }

--- a/src/app/search-page/search-page.html
+++ b/src/app/search-page/search-page.html
@@ -4,15 +4,15 @@
 			<div class="heroimg">
 				<img src="/assets/images/landing-img.jpg" alt="doctor typing" class="img-responsive">
 			</div>
-			<div class="searchcontent">
-				<div class="floating-left">
+			<div class="row">
+				<div class="col-md-6">
 					<ss-multiselect-dropdown
 						[options]="availableServiceCodes"
 						[(ngModel)]="selectedServiceCodes">
 					</ss-multiselect-dropdown>
 				</div>
 
-				<div class="floating-left">
+				<div class="col-md-6">
 					<location-picker #location></location-picker>
 					<div class="btn btn-default" [ngClass]="location?.latitude && location?.longitude && selectedServiceCodes && selectedServiceCodes.length ? '' : 'disabled'">
 						<a

--- a/src/styles.css
+++ b/src/styles.css
@@ -177,3 +177,9 @@ p {
 	padding: 0px;
 
 }
+
+ss-multiselect-dropdown .dropdown .btn {
+	min-width: 150px;
+	max-width: 250px;
+	white-space: normal;
+}


### PR DESCRIPTION
@viwinger The change that needed to be made to make it possible to center the dropdown and location picker was to remove the `class="flotaing-left"` from the two divs. I also made it so that text in the multi-select dropdown wraps if you select a bunch of options

Here is what it looks like now:
![image](https://cloud.githubusercontent.com/assets/5851984/22763165/b5da7992-ee28-11e6-8c4f-329e1086fe83.png)


Closes https://github.com/HealthConnectLink/HCL-FRONTEND/issues/39.